### PR TITLE
feat: add UI animations

### DIFF
--- a/components/dashboard/quick-actions.tsx
+++ b/components/dashboard/quick-actions.tsx
@@ -2,7 +2,7 @@
 
 import { Button } from "@/components/ui/button"
 import { useAuth } from "@/hooks/use-auth"
-import { Plus, Scan, CreditCard, FileText, Settings } from "lucide-react"
+import { Plus, Scan, CreditCard, FileText, Settings, Users } from "lucide-react"
 
 export function QuickActions() {
   const { hasPermission } = useAuth()
@@ -14,6 +14,13 @@ export function QuickActions() {
       href: "/students",
       permission: "students.write",
       color: "bg-blue-500 hover:bg-blue-600",
+    },
+    {
+      label: "Liste Étudiants",
+      icon: Users,
+      href: "/students",
+      permission: "students.read",
+      color: "bg-teal-500 hover:bg-teal-600",
     },
     {
       label: "Scanner RFID",
@@ -55,7 +62,7 @@ export function QuickActions() {
           <Button
             key={action.label}
             variant="outline"
-            className="justify-start h-12 glass bg-transparent hover:bg-white/20 dark:hover:bg-slate-800/20"
+            className="justify-start h-12 glass bg-transparent hover:bg-white/20 dark:hover:bg-slate-800/20 transition-transform duration-200 hover:scale-105 animate-fadeIn"
             onClick={() => (window.location.href = action.href)}
           >
             <div className={`p-2 rounded-lg ${action.color} mr-3`}>

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -9,7 +9,7 @@ const Card = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      "rounded-lg border bg-card text-card-foreground shadow-sm",
+      "rounded-lg border bg-card text-card-foreground shadow-sm animate-fadeIn",
       className
     )}
     {...props}

--- a/contexts/language-context.tsx
+++ b/contexts/language-context.tsx
@@ -76,6 +76,7 @@ const translations = {
     "settings.cancel": "Annuler",
 
     // RFID
+    "rfid.title": "Scanner RFID",
     "rfid.scanning": "Scan en cours...",
     "rfid.placeCard": "Placez votre carte RFID",
     "rfid.cardDetected": "Carte détectée",
@@ -146,6 +147,7 @@ const translations = {
     "settings.cancel": "إلغاء",
 
     // RFID
+    "rfid.title": "مسح RFID",
     "rfid.scanning": "جاري المسح...",
     "rfid.placeCard": "ضع بطاقة RFID الخاصة بك",
     "rfid.cardDetected": "تم اكتشاف البطاقة",
@@ -216,6 +218,7 @@ const translations = {
     "settings.cancel": "Cancel",
 
     // RFID
+    "rfid.title": "RFID Scan",
     "rfid.scanning": "Scanning...",
     "rfid.placeCard": "Place your RFID card",
     "rfid.cardDetected": "Card detected",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@radix-ui/react-toggle": "1.1.1",
     "@radix-ui/react-toggle-group": "1.1.1",
     "@radix-ui/react-tooltip": "latest",
-    "@tauri-apps/api": "latest",
+    "@tauri-apps/api": "^1.5.0",
     "autoprefixer": "^10.4.20",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
@@ -65,6 +65,7 @@
     "@types/node": "^22.17.0",
     "@types/react": "^18.3.23",
     "@types/react-dom": "^18",
+    "@tauri-apps/cli": "^1.5.0",
     "postcss": "^8.5",
     "tailwindcss": "^3.4.17",
     "typescript": "^5.9.2"

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -84,10 +84,15 @@ const config: Config = {
           from: { height: "var(--radix-accordion-content-height)" },
           to: { height: "0" },
         },
+        fadeIn: {
+          from: { opacity: "0", transform: "translateY(0.25rem)" },
+          to: { opacity: "1", transform: "translateY(0)" },
+        },
       },
       animation: {
         "accordion-down": "accordion-down 0.2s ease-out",
         "accordion-up": "accordion-up 0.2s ease-out",
+        fadeIn: "fadeIn 0.3s ease-out",
       },
       fontFamily: {
         heading: ["var(--font-heading)"],


### PR DESCRIPTION
## Summary
- animate cards and quick action buttons with new fade-in transition
- add student list option to dashboard quick actions
- define reusable fadeIn keyframes in Tailwind config
- add missing `rfid.title` translations so the scan page header localizes correctly

## Testing
- `npm install --no-fund --no-audit` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@tauri-apps%2fapi)*
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(prompts for ESLint configuration and exits)*
- `npm run build` *(fails: failed to fetch font `Inter`; module resolution errors for `@tauri-apps/api/tauri`; syntax error in app/reports/page.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_6895c63159388321908dda2a975bda48